### PR TITLE
changed CreateGlobalString() to CreateGlobalStringPtr()

### DIFF
--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -293,7 +293,7 @@ Generator::gen(Literal_expr const* e)
     // avoid redunancies.
     auto iter = strings.find(s);
     if (iter == strings.end()) {
-      llvm::Value* v = build.CreateGlobalString(s);
+      llvm::Value* v = build.CreateGlobalStringPtr(s);
       iter = strings.emplace(s, v).first;
     }
     return iter->second;


### PR DESCRIPTION
Code generation for string literals should use CreateGlobalStringPtr(). 

CreateGlobalString() returns a [n x i8]* which isn't usable in the way you would expect with c-string functions like puts(i8*) which expect a i8*.

 CreateGlobalStringPtr() creates the same global string but returns a GEP of type i8* through the array so it can be used like a regular c-string. 

example:
i8* getelementptr inbounds ([n x i8]* @1, i32 0, i32 0)