### PR TITLE
Revert "changed CreateGlobalString() to CreateGlobalStringPtr()"

### DIFF
--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -293,7 +293,7 @@ Generator::gen(Literal_expr const* e)
     // avoid redunancies.
     auto iter = strings.find(s);
     if (iter == strings.end()) {
-      llvm::Value* v = build.CreateGlobalStringPtr(s);
+      llvm::Value* v = build.CreateGlobalString(s);
       iter = strings.emplace(s, v).first;
     }
     return iter->second;


### PR DESCRIPTION
This reverts commit 485f288b2db5a40fc02e89a3518a7aec603b88db.

I'm dumb and didn't catch that block conversion was supposed to handle the GEP when necessary. Using CreateGlobalString() was actually correct. 