### PR TITLE
Improve compiler's command-line options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,27 @@
 
 # Project configuration
 cmake_minimum_required(VERSION 3.1)
-project(beaker C CXX)
+project(beaker VERSION 0.0 LANGUAGES C CXX)
 enable_testing()
+
+foreach(component MAJOR MINOR PATCH TWEAK)
+  if(PROJECT_VERSION_${component} STREQUAL "")
+    set(PROJECT_VERSION_${component} 0)
+  endif()
+endforeach()
+
+set(BEAKER_PACKAGE_NAME ${PROJECT_NAME})
+set(BEAKER_PACKAGE_TARNAME ${BEAKER_PACKAGE_NAME})
+set(BEAKER_PACKAGE_VERSION ${PROJECT_VERSION})
+set(BEAKER_PACKAGE_STRING "${BEAKER_PACKAGE_NAME} ${BEAKER_PACKAGE_VERSION}")
+set(BEAKER_PACKAGE_BUGREPORT "https://github.com/asutton/beaker/issues")
+set(BEAKER_PACKAGE_URL "https://github.com/asutton/beaker")
+
+set(BEAKER_VERSION ${PROJECT_VERSION})
+set(BEAKER_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(BEAKER_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(BEAKER_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(BEAKER_VERSION_TWEAK ${PROJECT_VERSION_TWEAK})
 
 # Boost dependencies
 find_package(Boost 1.55.0 REQUIRED COMPONENTS system filesystem program_options)
@@ -36,12 +55,12 @@ set(BEAKER_NATIVE_ARCHIVER ${CMAKE_AR})
 # Compiler configuration
 set(CMAKE_CXX_FLAGS "-Wall -std=c++1y")
 
+# TODO: Remove when 'lingo' submodule is updated.
+include_directories(lingo)
+
 if(NOT TARGET check)
   add_custom_target(check COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target test)
 endif()
-
-
-include_directories(lingo)
 
 add_subdirectory(lingo)
 add_subdirectory(beaker)

--- a/beaker/CMakeLists.txt
+++ b/beaker/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright (c) 2015 Andrew Sutton
 # All rights reserved
 
-# Generate a static configuration header in the
-# build directory.
+# Generate the configuration header.
 configure_file(config.hpp.in config.hpp)
 
 # Add the core Beaker library.
@@ -37,7 +36,7 @@ target_include_directories(
   beaker
     PUBLIC
       "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR};${PROJECT_BINARY_DIR}>"
-      lingo
+      ${lingo_SOURCE_DIR}
       ${Boost_INCLUDE_DIRS}
       ${LLVM_INCLUDE_DIRS}
 )

--- a/beaker/config.hpp.in
+++ b/beaker/config.hpp.in
@@ -1,18 +1,56 @@
 // Copyright (c) 2015 Andrew Sutton
 // All rights reserved
 
+/* config.hpp. Generated from config.hpp.in by cmake. */
+
 #ifndef BEAKER_CONFIG_HPP
 #define BEAKER_CONFIG_HPP
+
+/* Name of package. */
+#define BEAKER_PACKAGE "@BEAKER_PACKAGE_NAME@"
+
+/* Define to the full name of this package. */
+#define BEAKER_PACKAGE_NAME "@BEAKER_PACKAGE_NAME@"
+
+/* Define to the one symbol short name of this package. */
+#define BEAKER_PACKAGE_TARNAME "@BEAKER_PACKAGE_TARNAME@"
+
+/* Define to the version of this package. */
+#define BEAKER_PACKAGE_VERSION "@BEAKER_PACKAGE_VERSION@"
+
+/* Define to the full name and version of this package. */
+#define BEAKER_PACKAGE_STRING "@BEAKER_PACKAGE_STRING@"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define BEAKER_PACKAGE_BUGREPORT "@BEAKER_PACKAGE_BUGREPORT@"
+
+/* Define to the home page for this package. */
+#define BEAKER_PACKAGE_URL "@BEAKER_PACKAGE_URL@"
+
+/* The version number of the Beaker library. */
+#define BEAKER_VERSION "@BEAKER_VERSION@"
+
+/* The major version of the Beaker library. */
+#define BEAKER_VERSION_MAJOR @BEAKER_VERSION_MAJOR@
+
+/* The minor version of the Beaker library. */
+#define BEAKER_VERSION_MINOR @BEAKER_VERSION_MINOR@
+
+/* The patch version of the Beaker library. */
+#define BEAKER_VERSION_PATCH @BEAKER_VERSION_PATCH@
+
+/* The tweak version of the Beaker library. */
+#define BEAKER_VERSION_TWEAK @BEAKER_VERSION_TWEAK@
+
 
 // Tools
 #define BEAKER_LLVM_IR_COMPILER   "@LLVM_IR_COMPILER@"
 #define BEAKER_NATIVE_C_COMPILER  "@CMAKE_C_COMPILER@"
 #define BEAKER_NATIVE_AS          "@CMAKE_C_COMPILER@"
 #define BEAKER_NATIVE_LD          "@CMAKE_C_COMPILER@"
-
 #define BEAKER_NATIVE_AR          "@CMAKE_AR@"
 
-// File properties.
+// File properties
 #define BEAKER_OBJECT_EXT     "@CMAKE_C_OUTPUT_EXTENSION@"
 #define BEAKER_EXECUTABLE_EXT "@CMAKE_EXECUTABLE_SUFFIX@"
 #define BEAKER_LIBRARY_PRE    "@CMAKE_SHARED_LIBRARY_PREFIX@"

--- a/beaker/decl.cpp
+++ b/beaker/decl.cpp
@@ -3,8 +3,6 @@
 
 #include "beaker/decl.hpp"
 
-#include <iostream>
-
 
 Function_type const*
 Function_decl::type() const
@@ -30,25 +28,26 @@ Field_decl::index() const
   // FIXME: Why isn't this set in the constructor or
   // during elaboration.
   Decl_seq const& f = context()->fields();
-  for (std::size_t i = 0; i < f.size(); ++i)
+  for (std::size_t i = 0; i < f.size(); ++i) {
     if (f[i] == this) {
       path.push_back(i);
       return path;
     }
-
+  }
 
   Record_decl const* decl;
   while (decl->base_decl != nullptr) {
     decl = decl->base_decl;
     path.push_back(0);
     Decl_seq const& f = decl->fields();
-    for (std::size_t i = 0; i < f.size(); ++i)
+    for (std::size_t i = 0; i < f.size(); ++i) {
       if (f[i] == this) {
-          path.push_back(i);
-          return path;
+        path.push_back(i);
+        return path;
       }
+    }
   }
-  
+
   // If the last element is -1, it does not exist.
   path.push_back(-1);
   return path;

--- a/beaker/test/assign-2.bkr
+++ b/beaker/test/assign-2.bkr
@@ -1,4 +1,3 @@
-
 var x : int;
 
 def main() -> int

--- a/beaker/test/assign-3.bkr
+++ b/beaker/test/assign-3.bkr
@@ -1,4 +1,3 @@
-
 var a : int = 5;
 var x : int& = a;
 


### PR DESCRIPTION
I did a teensy bit of refactoring in beaker/compiler.cpp and added additional macros to the configuration header so that the output of `beaker-compile --version` (currently "beaker 0.0") is generated from the CMake project's `PROJECT_NAME` and `PROJECT_VERSION` variables.

Also, when you decide to update to the newest version of the 'lingo' submodule, please don't forget to remove the `include_directories()` command from the top-level CMakeLists.txt.