### PR TITLE
Adding Promote_conv

### DIFF
--- a/beaker/convert.cpp
+++ b/beaker/convert.cpp
@@ -10,59 +10,30 @@
 
 // this determines if a type can be promoted
 // promotion to the same type is not valid
-bool
-can_promote(Expr* e, Type const* t)
-{    
-    // static types
-    static Type const* char_type = get_character_type();
-    static Type const* float_type = get_float_type();
-    static Type const* double_type = get_double_type();
+Type const*
+get_promotion_target(Expr* first, Expr* second)
+{        
+    // get type of both expressions
+    Type const* first_t = first->type();
+    Type const* second_t = second->type();
     
-    // check for type match
-    if (e->type() == t)
-        return false;
+    // if the same type use that as the target
+    if (first_t == second_t)
+        return first_t;
     
-    // nothing can become a char
-    if (t == char_type)
-        return false;
-    
-    // char can become an integer or floating point
-    if (e->type() == char_type)
-        return true;
-    
-    // integer types
-    if (is_integer(e->type())) {
-        // integers can become either floating point type
-        if (t == float_type || t == double_type)
-            return true;
-        
-        // must cast as Integer_type* to allow access to precision and sign
-        const Integer_type* et = dynamic_cast<const Integer_type*>(e->type());
-        const Integer_type* tt = dynamic_cast<const Integer_type*>(t);
-        
-        // integers can become a greater percision
-        if (et->precision() < tt->precision())
-            return true;
-        
-        // integers can move from unsigned to signed
-        if ((et->precision() == tt->precision()) && (et->is_signed() < tt->is_signed()))
-            return true;
-    }
-    
-    // float can become a double
-    if (e->type() == float_type && t == double_type)
-        return true;
-    
-    // default
-    return false;
+    // make highest rank the target
+    if (get_scalar_rank(first_t) > get_scalar_rank(second_t))
+        return first_t;
+    else
+        return second_t;
 }
 
 // if promotion is not allowed then the origninal
 // expr is returned. This allows for operations 
 // with same types to occur.
 Expr*
-try_promote(Expr* e, Type const* t){
-    if (can_promote(e,t))
+promote(Expr* e, Type const* t){
+    if (get_scalar_rank(t) > get_scalar_rank(e->type()))
         return new Promote_conv(t,e);
     else
         return e;
@@ -167,10 +138,20 @@ convert(Expr* e, Type const* t)
       if (c->type() == t)
         return c;
   }
-    
+
+  // convert to boolean
+  if (is<Boolean_type>(t)) {
+      // Need another convert class
+      // 0                ->  false
+      // everything else  ->  true
+      throw std::runtime_error("not implemented");
+  }
+
   // Try to apply a type promotion
-  if (is<Integer_type>(t) || is<Float_type>(t) || is<Double_type>(t)) {
-    return try_promote(e,t);
+  if (is_scalar(t)) {
+    c = promote(e,t);
+    if (c->type() == t)
+        return c;
   }
 
   // If we've exhaused all possible conversions without matching 

--- a/beaker/convert.cpp
+++ b/beaker/convert.cpp
@@ -8,14 +8,23 @@
 
 #include <iostream>
 
-// this determines if a type can be promoted
-// promotion to the same type is not valid
+// This finds the target that both operands should
+// be converted to.  Default int32.
 Type const*
 get_promotion_target(Expr* first, Expr* second)
 {        
     // get type of both expressions
     Type const* first_t = first->type();
     Type const* second_t = second->type();
+    
+    // if both are not scalar, default is int32
+    // if one is not scalar, choose the other type
+    if (!is_scalar(first_t) && !is_scalar(second_t))
+        return get_integer_type();
+    else if (!is_scalar(first_t))
+        return second_t;
+    else if (!is_scalar(second_t))
+        return first_t;
     
     // if the same type use that as the target
     if (first_t == second_t)
@@ -26,6 +35,22 @@ get_promotion_target(Expr* first, Expr* second)
         return first_t;
     else
         return second_t;
+}
+
+// This finds the target that the operand should
+// be converted to. Default int32.
+Type const*
+get_promotion_target(Expr* first)
+{        
+    // get type of expression
+    Type const* first_t = first->type();
+    
+    // if not scalar, default is int32
+    if (!is_scalar(first_t))
+        return get_integer_type();
+    
+    // if it is scalar then type remains
+    return first_t;
 }
 
 // if promotion is not allowed then the origninal

--- a/beaker/convert.cpp
+++ b/beaker/convert.cpp
@@ -28,7 +28,7 @@ can_promote(Expr* e, Type const* t)
     
     // char can become an integer or floating point
     if (e->type() == char_type)
-            return true;
+        return true;
     
     // integer types
     if (is_integer(e->type())) {
@@ -45,7 +45,7 @@ can_promote(Expr* e, Type const* t)
             return true;
         
         // integers can move from unsigned to signed
-        if (et->is_signed() < tt->is_signed())
+        if ((et->precision() == tt->precision()) && (et->is_signed() < tt->is_signed()))
             return true;
     }
     
@@ -170,9 +170,7 @@ convert(Expr* e, Type const* t)
     
   // Try to apply a type promotion
   if (is<Integer_type>(t) || is<Float_type>(t) || is<Double_type>(t)) {
-    c = try_promote(e,t);
-    if (c->type() == t)
-        return c;
+    return try_promote(e,t);
   }
 
   // If we've exhaused all possible conversions without matching 

--- a/beaker/convert.hpp
+++ b/beaker/convert.hpp
@@ -16,6 +16,7 @@ Expr*    convert(Expr*, Type const*);
 Expr_seq convert(Expr_seq const&, Type_seq const&);
 
 Expr* convert_to_value(Expr*);
-
+bool can_promote(Expr*, Type const*);
+Expr* try_promote(Expr*, Type const*);
 
 #endif

--- a/beaker/convert.hpp
+++ b/beaker/convert.hpp
@@ -16,7 +16,7 @@ Expr*    convert(Expr*, Type const*);
 Expr_seq convert(Expr_seq const&, Type_seq const&);
 
 Expr* convert_to_value(Expr*);
-bool can_promote(Expr*, Type const*);
-Expr* try_promote(Expr*, Type const*);
+Type const* get_promotion_target(Expr*, Expr*);
+Expr* promote(Expr*, Type const*);
 
 #endif

--- a/beaker/convert.hpp
+++ b/beaker/convert.hpp
@@ -17,6 +17,7 @@ Expr_seq convert(Expr_seq const&, Type_seq const&);
 
 Expr* convert_to_value(Expr*);
 Type const* get_promotion_target(Expr*, Expr*);
+Type const* get_promotion_target(Expr*);
 Expr* promote(Expr*, Type const*);
 
 #endif

--- a/beaker/elaborator.cpp
+++ b/beaker/elaborator.cpp
@@ -345,6 +345,7 @@ Elaborator::elaborate(Expr* e)
     Expr* operator()(Index_expr* e) const { return elab.elaborate(e); }
     Expr* operator()(Value_conv* e) const { return elab.elaborate(e); }
     Expr* operator()(Block_conv* e) const { return elab.elaborate(e); }
+    Expr* operator()(Promote_conv* e) const { return elab.elaborate(e); }
     Expr* operator()(Default_init* e) const { return elab.elaborate(e); }
     Expr* operator()(Copy_init* e) const { return elab.elaborate(e); }
     Expr* operator()(Reference_init* e) const { return elab.elaborate(e); }
@@ -1152,6 +1153,13 @@ Elaborator::elaborate(Value_conv* e)
 
 Expr*
 Elaborator::elaborate(Block_conv* e)
+{
+  return e;
+}
+
+
+Expr*
+Elaborator::elaborate(Promote_conv* e)
 {
   return e;
 }

--- a/beaker/elaborator.cpp
+++ b/beaker/elaborator.cpp
@@ -463,17 +463,17 @@ template<typename T>
 Expr*
 check_binary_arithmetic_expr(Elaborator& elab, T* e)
 {
-  Type const* z = get_integer_type();
-  Expr* c1 = require_converted(elab, e->first, z);
-  Expr* c2 = require_converted(elab, e->second, z);
+  Type const* t = get_promotion_target(e->first, e->second);
+  Expr* c1 = require_converted(elab, e->first, t);
+  Expr* c2 = require_converted(elab, e->second, t);
   if (!c1)
-    throw Type_error({}, "left operand cannot be converted to 'int'");
+    throw Type_error({}, "left operand cannot be converted");
   if (!c2)
-    throw Type_error({}, "right operand cannot be converted to 'int'");
+    throw Type_error({}, "right operand cannot be converted");
 
   // Rebuild the expression with the
   // converted operands.
-  e->type_ = z;
+  e->type_ = t;
   e->first = c1;
   e->second = c2;
   return e;

--- a/beaker/elaborator.cpp
+++ b/beaker/elaborator.cpp
@@ -489,13 +489,13 @@ Expr*
 check_unary_arithmetic_expr(Elaborator& elab, T* e)
 {
   // Apply conversions
-  Type const* z = get_integer_type();
-  Expr* c = require_converted(elab, e->first, z);
+  Type const* t = get_promotion_target(e->first);
+  Expr* c = require_converted(elab, e->first, t);
   if (!c)
-    throw Type_error({}, "operand cannot be converted to 'int'");
+    throw Type_error({}, "operand cannot be converted");
 
   // Rebuild the expression with the converted operands.
-  e->type_ = z;
+  e->type_ = t;
   e->first = c;
   return e;
 }
@@ -612,14 +612,14 @@ Expr*
 check_ordering_expr(Elaborator& elab, Binary_expr* e)
 {
   // Apply conversions.
-  Type const* z = get_integer_type();
+  Type const* t = get_promotion_target(e->first, e->second);
   Type const* b = get_boolean_type();
-  Expr* c1 = require_converted(elab, e->first, z);
-  Expr* c2 = require_converted(elab, e->second, z);
+  Expr* c1 = require_converted(elab, e->first, t);
+  Expr* c2 = require_converted(elab, e->second, t);
   if (!c1)
-    throw Type_error({}, "left operand cannot be converted to 'int'");
+    throw Type_error({}, "left operand cannot be converted");
   if (!c2)
-    throw Type_error({}, "right operand cannot be converted to 'int'");
+    throw Type_error({}, "right operand cannot be converted");
 
   // Rebuild the expression with the converted
   // operands.

--- a/beaker/elaborator.hpp
+++ b/beaker/elaborator.hpp
@@ -80,6 +80,7 @@ public:
   Expr* elaborate(Index_expr* e);
   Expr* elaborate(Value_conv* e);
   Expr* elaborate(Block_conv* e);
+  Expr* elaborate(Promote_conv* e);
   Expr* elaborate(Default_init* e);
   Expr* elaborate(Copy_init* e);
   Expr* elaborate(Reference_init* e);

--- a/beaker/evaluator.cpp
+++ b/beaker/evaluator.cpp
@@ -45,13 +45,10 @@ Evaluator::eval(Expr const* e)
     Value operator()(Value_conv const* e) { return ev.eval(e); }
     Value operator()(Block_conv const* e) { return ev.eval(e); }
     Value operator()(Base_conv const* e) { return ev.eval(e); }
+    Value operator()(Promote_conv const* e) { return ev.eval(e); }
     
     // Initializers are not evaluated like normal expressions.
     Value operator()(Init const* e) { lingo_unreachable(); }
-    Value operator()(Promote_conv const* e) { return ev.eval(e); }
-    Value operator()(Default_init const* e) { return ev.eval(e); }
-    Value operator()(Copy_init const* e) { return ev.eval(e); }
-    Value operator()(Reference_init const* e) { return ev.eval(e); }
   };
 
   return apply(e, Fn {*this});

--- a/beaker/evaluator.cpp
+++ b/beaker/evaluator.cpp
@@ -44,6 +44,7 @@ Evaluator::eval(Expr const* e)
     Value operator()(Index_expr const* e) { return ev.eval(e); }
     Value operator()(Value_conv const* e) { return ev.eval(e); }
     Value operator()(Block_conv const* e) { return ev.eval(e); }
+    Value operator()(Promote_conv const* e) { return ev.eval(e); }
     Value operator()(Default_init const* e) { return ev.eval(e); }
     Value operator()(Copy_init const* e) { return ev.eval(e); }
     Value operator()(Reference_init const* e) { return ev.eval(e); }
@@ -351,6 +352,13 @@ Evaluator::eval(Value_conv const* e)
 // to a reference.
 Value
 Evaluator::eval(Block_conv const* e)
+{
+  throw std::runtime_error("not implemented");
+}
+
+// Apply a promotion
+Value
+Evaluator::eval(Promote_conv const* e)
 {
   throw std::runtime_error("not implemented");
 }

--- a/beaker/evaluator.hpp
+++ b/beaker/evaluator.hpp
@@ -68,6 +68,7 @@ public:
   Value eval(Index_expr const*);
   Value eval(Value_conv const*);
   Value eval(Block_conv const*);
+  Value eval(Promote_conv const*);
   Value eval(Default_init const*);
   Value eval(Copy_init const*);
   Value eval(Reference_init const*);

--- a/beaker/evaluator.hpp
+++ b/beaker/evaluator.hpp
@@ -70,9 +70,6 @@ public:
   Value eval(Block_conv const*);
   Value eval(Base_conv const*);
   Value eval(Promote_conv const*);
-  Value eval(Default_init const*);
-  Value eval(Copy_init const*);
-  Value eval(Reference_init const*);
 
   void eval_init(Expr const*, Value&);
   void eval_init(Default_init const*, Value&);

--- a/beaker/expr.hpp
+++ b/beaker/expr.hpp
@@ -71,6 +71,7 @@ struct Expr::Visitor
   virtual void visit(Index_expr const*) = 0;
   virtual void visit(Value_conv const*) = 0;
   virtual void visit(Block_conv const*) = 0;
+  virtual void visit(Promote_conv const*) = 0;
   virtual void visit(Default_init const*) = 0;
   virtual void visit(Copy_init const*) = 0;
   virtual void visit(Reference_init const*) = 0;
@@ -108,6 +109,7 @@ struct Expr::Mutator
   virtual void visit(Index_expr*) = 0;
   virtual void visit(Value_conv*) = 0;
   virtual void visit(Block_conv*) = 0;
+  virtual void visit(Promote_conv*) = 0;
   virtual void visit(Default_init*) = 0;
   virtual void visit(Copy_init*) = 0;
   virtual void visit(Reference_init*) = 0;
@@ -543,6 +545,15 @@ struct Block_conv : Conv
   void accept(Mutator& v)       { v.visit(this); }
 };
 
+// Represents the promoton of a numeric type
+struct Promote_conv : Conv
+{
+  using Conv::Conv;
+
+  void accept(Visitor& v) const { v.visit(this); }
+  void accept(Mutator& v)       { v.visit(this); }
+};
+
 
 // -------------------------------------------------------------------------- //
 // Initializers
@@ -676,6 +687,7 @@ struct Generic_expr_visitor : Expr::Visitor, lingo::Generic_visitor<F, T>
   void visit(Index_expr const* e) { this->invoke(e); }
   void visit(Value_conv const* e) { this->invoke(e); }
   void visit(Block_conv const* e) { this->invoke(e); }
+  void visit(Promote_conv const* e) { this->invoke(e); }
   void visit(Default_init const* e) { this->invoke(e); }
   void visit(Copy_init const* e) { this->invoke(e); }
   void visit(Reference_init const* e) { this->invoke(e); }
@@ -729,6 +741,7 @@ struct Generic_expr_mutator : Expr::Mutator, lingo::Generic_mutator<F, T>
   void visit(Index_expr* e) { this->invoke(e); }
   void visit(Value_conv* e) { this->invoke(e); }
   void visit(Block_conv* e) { this->invoke(e); }
+  void visit(Promote_conv* e) { this->invoke(e); }
   void visit(Default_init* e) { this->invoke(e); }
   void visit(Copy_init* e) { this->invoke(e); }
   void visit(Reference_init* e) { this->invoke(e); }

--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -229,6 +229,7 @@ Generator::gen(Expr const* e)
     llvm::Value* operator()(Method_expr const* e) const { return g.gen(e); }
     llvm::Value* operator()(Index_expr const* e) const { return g.gen(e); }
     llvm::Value* operator()(Value_conv const* e) const { return g.gen(e); }
+    llvm::Value* operator()(Promote_conv const* e) const { return g.gen(e); }
     llvm::Value* operator()(Block_conv const* e) const { return g.gen(e); }
     llvm::Value* operator()(Default_init const* e) const { return g.gen(e); }
     llvm::Value* operator()(Copy_init const* e) const { return g.gen(e); }
@@ -601,6 +602,12 @@ Generator::gen(Value_conv const* e)
 {
   llvm::Value* v = gen(e->source());
   return build.CreateLoad(v);
+}
+
+llvm::Value*
+Generator::gen(Promote_conv const* e)
+{
+  throw std::runtime_error("not implemented");
 }
 
 

--- a/beaker/generator.hpp
+++ b/beaker/generator.hpp
@@ -96,9 +96,6 @@ struct Generator
   llvm::Value* gen(Block_conv const*);
   llvm::Value* gen(Base_conv const*);
   llvm::Value* gen(Promote_conv const*);
-  llvm::Value* gen(Default_init const*);
-  llvm::Value* gen(Copy_init const*);
-  llvm::Value* gen(Reference_init const*);
 
   void gen_init(llvm::Value*, Expr const*);
   void gen_init(llvm::Value*, Default_init const*);

--- a/beaker/generator.hpp
+++ b/beaker/generator.hpp
@@ -94,6 +94,7 @@ struct Generator
   llvm::Value* gen(Index_expr const*);
   llvm::Value* gen(Value_conv const*);
   llvm::Value* gen(Block_conv const*);
+  llvm::Value* gen(Promote_conv const*);
   llvm::Value* gen(Default_init const*);
   llvm::Value* gen(Copy_init const*);
   llvm::Value* gen(Reference_init const*);

--- a/beaker/less.cpp
+++ b/beaker/less.cpp
@@ -211,6 +211,7 @@ is_less(Expr const* a, Expr const* b)
     bool operator()(Index_expr const* a) { lingo_unreachable(); }
     bool operator()(Value_conv const* a) { lingo_unreachable(); }
     bool operator()(Block_conv const* a) { lingo_unreachable(); }
+    bool operator()(Promote_conv const* a) { lingo_unreachable(); }
     bool operator()(Default_init const* a) { lingo_unreachable(); }
     bool operator()(Copy_init const* a) { lingo_unreachable(); }
     bool operator()(Reference_init const* a) { lingo_unreachable(); }

--- a/beaker/prelude.hpp
+++ b/beaker/prelude.hpp
@@ -58,6 +58,7 @@ struct Index_expr;
 struct Conv;
 struct Value_conv;
 struct Block_conv;
+struct Promote_conv;
 struct Init;
 struct Default_init;
 struct Copy_init;

--- a/beaker/print.cpp
+++ b/beaker/print.cpp
@@ -156,6 +156,7 @@ operator<<(std::ostream& os, Expr const& e)
     void operator()(Index_expr const* e) { os << *e; }
     void operator()(Value_conv const* e) { os << *e; }
     void operator()(Block_conv const* e) { os << *e; }
+    void operator()(Promote_conv const* e) { os << *e; }
     void operator()(Default_init const* e) { os << *e; }
     void operator()(Copy_init const* e) { os << *e; }
     void operator()(Reference_init const* e) { os << *e; }
@@ -347,6 +348,15 @@ std::ostream&
 operator<<(std::ostream& os, Block_conv const& e)
 {
   return os << "__to_block("
+            << *e.source() << ','
+            << *e.target() << ')';
+}
+
+
+std::ostream&
+operator<<(std::ostream& os, Promote_conv const& e)
+{
+  return os << "__promote("
             << *e.source() << ','
             << *e.target() << ')';
 }

--- a/beaker/print.hpp
+++ b/beaker/print.hpp
@@ -48,6 +48,7 @@ std::ostream& operator<<(std::ostream&, Method_expr const&);
 std::ostream& operator<<(std::ostream&, Index_expr const&);
 std::ostream& operator<<(std::ostream&, Value_conv const&);
 std::ostream& operator<<(std::ostream&, Block_conv const&);
+std::ostream& operator<<(std::ostream&, Promote_conv const&);
 std::ostream& operator<<(std::ostream&, Default_init const&);
 std::ostream& operator<<(std::ostream&, Copy_init const&);
 std::ostream& operator<<(std::ostream&, Reference_init const&);

--- a/beaker/type.cpp
+++ b/beaker/type.cpp
@@ -217,6 +217,48 @@ get_record_type(Record_decl* r)
   return &*ins.first;
 }
 
+// Gets the rank of a type
+int
+get_scalar_rank(Type const* t)
+{
+    // static types
+    static Type const* b = get_boolean_type();
+    static Type const* c = get_character_type();
+    static Type const* ui16 = get_integer_type(false,16);
+    static Type const* i16 = get_integer_type(16);
+    static Type const* ui32 = get_integer_type(false);
+    static Type const* i32 = get_integer_type();
+    static Type const* ui64 = get_integer_type(false,64);
+    static Type const* i64 = get_integer_type(64);
+    static Type const* f = get_float_type();
+    static Type const* d = get_double_type();
+    
+    // return rank
+    if (t == b)
+        return bool_rnk;
+    if (t == c)
+        return char_rnk;
+    if (t == ui16)
+        return uint16_rnk;
+    if (t == i16)
+        return int16_rnk;
+    if (t == ui32)
+        return uint32_rnk;
+    if (t == i32)
+        return int32_rnk;
+    if (t == ui64)
+        return uint64_rnk;
+    if (t == i64)
+        return int64_rnk;
+    if (t == f)
+        return float_rnk;
+    if (t == d)
+        return double_rnk;
+    
+    // default case
+    return default_rnk;
+}
+
 bool
 is_derived(Type const* derived, Type const* base){
   if (Record_type const* d = as<Record_type>(derived))  {

--- a/beaker/type.hpp
+++ b/beaker/type.hpp
@@ -269,6 +269,12 @@ is_string(Type const* t)
     return false;
 }
 
+// Returns true if this is the type of an int
+inline bool
+is_integer(Type const* t)
+{
+  return is<Integer_type>(t);
+}
 
 // -------------------------------------------------------------------------- //
 //                              Generic visitors

--- a/beaker/type.hpp
+++ b/beaker/type.hpp
@@ -242,7 +242,9 @@ is_scalar(Type const* t)
 {
   return is<Boolean_type>(t)
       || is<Character_type>(t)
-      || is<Integer_type>(t);
+      || is<Integer_type>(t)
+      || is<Float_type>(t)
+      || is<Double_type>(t);
 }
 
 
@@ -270,12 +272,27 @@ is_string(Type const* t)
     return false;
 }
 
-// Returns true if this is the type of an int
-inline bool
-is_integer(Type const* t)
+
+int
+get_scalar_rank(Type const*);
+
+
+// scalar ranks
+enum Scalar_rank
 {
-  return is<Integer_type>(t);
-}
+    default_rnk = -1,
+    bool_rnk,
+    char_rnk,
+    uint16_rnk,
+    int16_rnk,
+    uint32_rnk,
+    int32_rnk,
+    uint64_rnk,
+    int64_rnk,
+    float_rnk,
+    double_rnk
+};
+
 
 // -------------------------------------------------------------------------- //
 //                              Generic visitors


### PR DESCRIPTION
The Promote_conv class will be used to promote a number to another type of higher precision and sign